### PR TITLE
Add github actions workflows to upload the pkg to pypi and testpypi

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,16 @@
+name: Release
+on:
+  release:
+    types: [published]
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+        architecture: 'x64'
+    - run: pip install poetry==1.1.12
+    - run: poetry build
+    - run: poetry publish --username=__token__ --password=${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -1,0 +1,25 @@
+name: TestPyPI
+on:
+  push:
+    branches:
+      - master
+jobs:
+  test_pypi:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+        architecture: 'x64'
+    - run: pip install poetry==1.1.12
+    - run: >-
+        poetry version patch &&
+        version=$(poetry version | awk '{print $2}') &&
+        poetry version $version.dev.$(date +%s)
+    - run: poetry build
+    - uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Changes:

* Add a directory called workflows to store the GitHub Actions config files
* Add a GitHub Action config file to upload the pkg to PyPI
*  Add a GitHub Action config file to upload the pkg to Test PyPI

To make this work, the admin has to add two secrets to the repository, `TEST_PYPI_TOKEN` and `PYPI_TOKEN` for test PyPI and PyPI, respectively.